### PR TITLE
Use class weights for ModernBERT training

### DIFF
--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -28,6 +28,7 @@ training:
   save_steps: 500
   eval_steps: 500
   logging_steps: 100
+  use_class_weights: true
   
 # 評価設定
 evaluation:

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,11 @@ from sklearn.model_selection import train_test_split
 # 自作モジュールのインポート
 from data.preprocessing import DataPreprocessor, setup_logging
 from models.baseline_models import create_baseline_models, BaselineEvaluator
-from models.modernbert_classifier import create_modernbert_model, ModernBERTTrainer
+from models.modernbert_classifier import (
+    create_modernbert_model,
+    ModernBERTTrainer,
+    calculate_class_weights,
+)
 from models.ensemble_model import EnsembleModel
 from data.dataset import create_data_loaders
 from evaluation.metrics import ModelEvaluator, MetricsCalculator
@@ -181,9 +185,15 @@ def phase2_modernbert_training(config: Dict, logger: logging.Logger) -> Dict:
     train_df = pd.read_csv(processed_dir / 'train_processed.csv')
     val_df = pd.read_csv(processed_dir / 'val_processed.csv')
     
+    # クラス重みを計算（クラス不均衡対策）
+    class_weights = None
+    if config['training'].get('use_class_weights'):
+        target_col = config['data']['target_column']
+        class_weights = calculate_class_weights(train_df[target_col].tolist())
+
     # ModernBERTモデルとトークナイザーを作成
     logger.info("ModernBERTモデルを初期化します")
-    model, tokenizer = create_modernbert_model(config)
+    model, tokenizer = create_modernbert_model(config, class_weights=class_weights)
     
     # データローダーを作成
     logger.info("データローダーを作成します")

--- a/test_setup.py
+++ b/test_setup.py
@@ -16,7 +16,7 @@ def test_imports():
     
     required_packages = [
         'pandas', 'numpy', 'torch', 'transformers',
-        'scikit-learn', 'matplotlib', 'seaborn', 'yaml', 'tqdm', 'lightgbm'
+        'sklearn', 'matplotlib', 'seaborn', 'yaml', 'tqdm', 'lightgbm'
     ]
     
     failed_imports = []


### PR DESCRIPTION
## Summary
- Support class-weighted loss in ModernBERTClassifier and builder
- Compute class weights from training labels and enable via config
- Fix setup test to import `sklearn`

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68aea282e0848328b7c3446f0bfb0444