### PR TITLE
Refine LightGBM Optuna search space

### DIFF
--- a/src/models/baseline_models.py
+++ b/src/models/baseline_models.py
@@ -410,11 +410,12 @@ class TFIDFLightGBM(BaselineModel):
             'classifier__learning_rate': FloatDistribution(1e-3, 0.3, log=True),
             'classifier__num_leaves': IntDistribution(20, 150),
             'classifier__max_depth': IntDistribution(3, 12),
-            'classifier__min_child_samples': IntDistribution(5, 100),
+            'classifier__min_child_samples': IntDistribution(1, 100),
             'classifier__subsample': FloatDistribution(0.6, 1.0),
             'classifier__colsample_bytree': FloatDistribution(0.6, 1.0),
-            'classifier__reg_alpha': FloatDistribution(0.0, 10.0),
-            'classifier__reg_lambda': FloatDistribution(0.0, 10.0)
+            'classifier__reg_alpha': FloatDistribution(1e-8, 1.0, log=True),
+            'classifier__reg_lambda': FloatDistribution(1e-8, 1.0, log=True),
+            'classifier__min_split_gain': FloatDistribution(0.0, 0.2)
         }
         cv = StratifiedKFold(
             n_splits=self.config['evaluation']['cv_folds'],


### PR DESCRIPTION
## Summary
- Narrow Optuna's LightGBM search space to avoid over-regularized models that produced `best gain: -inf` warnings.
- Add `min_split_gain` tuning and allow smaller `min_child_samples` to help model find valid splits.

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeb66608cc832883e0d4c8fd9e72f9